### PR TITLE
[feat] 외부 스토어 사용할 수 있도록 Store Class 및 관련 훅 구현

### DIFF
--- a/src/hooks/useForceUpdate.ts
+++ b/src/hooks/useForceUpdate.ts
@@ -1,0 +1,9 @@
+import { useCallback, useState } from 'react';
+
+const useForceUpdate = () => {
+  const [, setState] = useState({});
+
+  return useCallback(() => setState({}), []);
+};
+
+export default useForceUpdate;

--- a/src/hooks/useStore.ts
+++ b/src/hooks/useStore.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+import Store from '../stores/Store';
+
+import useForceUpdate from './useForceUpdate';
+
+const useStore = <T extends Store>(store: T) => {
+  const forceUpdate = useForceUpdate();
+
+  useEffect(() => {
+    store.subscribe(forceUpdate);
+
+    return () => store.unsubscribe(forceUpdate);
+  }, [forceUpdate]);
+
+  return store;
+};
+
+export default useStore;

--- a/src/stores/Store.ts
+++ b/src/stores/Store.ts
@@ -1,0 +1,21 @@
+type Listener = () => void;
+
+export default class Store {
+  listeners : Set<Listener>;
+
+  constructor() {
+    this.listeners = new Set();
+  }
+
+  subscribe(listener: Listener) {
+    this.listeners.add(listener);
+  }
+
+  unsubscribe(listener: Listener) {
+    this.listeners.delete(listener);
+  }
+
+  publish() {
+    this.listeners.forEach((listener) => listener());
+  }
+}


### PR DESCRIPTION
- 외부 스토어를 구독, 스토어 내의 상태 업데이트를 정의한 Store Class 구현
- 구독된 외부 스토어의 상태 업데이트를 해주는 `useForceUpdate` hook 구현
- 여러 외부 스토어의 구독과 구독 해제를 도와주고, 스토어 내의 상태와 메서드를 반환시켜주는 `useStore` 구현

[외부 스토어 사용법]
1. 각 기능과 관련된 스토어를 Store Class에게 상속받아 생성(상태 변수와 메서드를 정의할 수 있음), 인스턴스를 생성하여 내보내기
2. 1번에서 생산한 스토어의 이름으로 된 hook을 만들고, `useStore(인스턴스)` 을 반환
3. 외부 스토어를 사용할 때, 2번에서 만든 hook에게서 반환받은 `store`로 상태를 불러오거나 메서드를 사용