### PR TITLE
[feat] Todo List 화면 및 모든 기능 구현

### DIFF
--- a/src/components/TodoAddField.tsx
+++ b/src/components/TodoAddField.tsx
@@ -1,0 +1,58 @@
+import styled from 'styled-components';
+
+import useTodoStore from '../hooks/useTodoStore';
+
+import TEST_ID from '../constants/testId';
+
+import TextInputBox from './ui/TextInputBox';
+import Button from './ui/Button';
+
+export default function TodoAddField() {
+  const store = useTodoStore();
+
+  const handleChangeInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+    store.changeTodo(event.target.value);
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    await store.createTodo(store.todo);
+  };
+
+  return (
+    <Container>
+      <form onSubmit={handleSubmit}>
+        <TextInputBox
+          label="할 일 추가"
+          type="text"
+          value={store.todo}
+          testId={TEST_ID.TODO.ADD_INPUT}
+          onChange={handleChangeInput}
+        />
+        <Button
+          type="submit"
+          data-testid={TEST_ID.TODO.ADD_BUTTON}
+          disabled={!store.todo}
+        >
+          추가
+        </Button>
+      </form>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  padding-block: 2rem;
+
+  form{
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    button{
+      margin-left: 1rem;
+      white-space: nowrap;
+    }
+  }
+`;

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react';
+
+import styled from 'styled-components';
+
+import useTodoStore from '../hooks/useTodoStore';
+
+import TEST_ID from '../constants/testId';
+
+import { TodoItem as TodoItemType } from '../types';
+
+import TodoItemEdit from './TodoItemEdit';
+
+interface TodoItemProps {
+  todoItem: TodoItemType;
+}
+
+export default function TodoItem({ todoItem } : TodoItemProps) {
+  const store = useTodoStore();
+
+  const [modifyMode, setModifyMode] = useState(false);
+
+  const handleChangeCheckbox = () => {
+    store.updateTodo(
+      todoItem.id,
+      todoItem.todo,
+      !todoItem.isCompleted,
+    );
+  };
+
+  const handleClickModify = () => {
+    setModifyMode(true);
+  };
+
+  const handleClickDelete = () => {
+    store.deleteTodo(todoItem.id);
+  };
+
+  return (
+    <Container>
+      <input
+        type="checkbox"
+        checked={todoItem.isCompleted}
+        onChange={handleChangeCheckbox}
+      />
+
+      {!modifyMode ? (
+        <>
+          <span>{todoItem.todo}</span>
+
+          <button
+            type="button"
+            onClick={handleClickModify}
+            data-testid={TEST_ID.TODO.MODIFY_BUTTON}
+          >
+            수정
+          </button>
+
+          <button
+            type="button"
+            onClick={handleClickDelete}
+            data-testid={TEST_ID.TODO.DELETE_BUTTON}
+          >
+            삭제
+          </button>
+        </>
+      ) : (
+        <TodoItemEdit
+          todoItem={todoItem}
+          setModifyMode={setModifyMode}
+        />
+      )}
+    </Container>
+  );
+}
+
+const Container = styled.li`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  max-width: 60rem;
+  padding: 1.2rem 1rem;
+
+  &:nth-child(odd){
+    background-color: #e5f9f2;
+  }
+
+  :nth-child(2) {
+    flex-grow: 1;
+    margin-inline: .8rem;
+  }
+
+  span{
+    display: inline-block;
+  }
+
+  input[type='text']{
+    padding: .4rem;
+    border: none;
+    border-bottom: 1px solid #777;
+    background-color: transparent;
+
+    &:focus{
+      outline: none;
+    }
+  }
+
+  button{
+    margin-inline: .3rem;
+    color: #777;
+    text-decoration: underline;
+  }
+`;

--- a/src/components/TodoItemEdit.tsx
+++ b/src/components/TodoItemEdit.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+
+import useTodoStore from '../hooks/useTodoStore';
+
+import { TodoItem } from '../types';
+
+import TEST_ID from '../constants/testId';
+
+interface TodoItemEditProps {
+  todoItem: TodoItem;
+  setModifyMode: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export default function TodoItemEdit({
+  todoItem, setModifyMode,
+}: TodoItemEditProps) {
+  const store = useTodoStore();
+
+  const [value, setValue] = useState('');
+
+  useEffect(() => {
+    setValue(todoItem.todo);
+  }, []);
+
+  const handleChangeInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      onSubmit();
+    }
+
+    if (event.key === 'Escape') {
+      onCancel();
+    }
+  };
+
+  const onSubmit = () => {
+    store.updateTodo(todoItem.id, value, todoItem.isCompleted);
+
+    setModifyMode(false);
+  };
+
+  const onCancel = () => {
+    setModifyMode(false);
+  };
+
+  return (
+    <>
+      <input
+        type="text"
+        value={value}
+        data-testid={TEST_ID.TODO.MODIFY_INPUT}
+        onChange={handleChangeInput}
+        onKeyDown={handleKeyDown}
+      />
+
+      <button
+        type="button"
+        onClick={onSubmit}
+        data-testid={TEST_ID.TODO.SUBMIT_BUTTON}
+      >
+        제출
+      </button>
+
+      <button
+        type="button"
+        onClick={onCancel}
+        data-testid={TEST_ID.TODO.CANCEL_BUTTON}
+      >
+        취소
+      </button>
+    </>
+  );
+}

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+
+import styled from 'styled-components';
+
+import useTodoStore from '../hooks/useTodoStore';
+
+import TodoItem from './TodoItem';
+
+export default function TodoList() {
+  const store = useTodoStore();
+
+  useEffect(() => {
+    store.fetchTodoList();
+  }, []);
+
+  if (store.todoList.length === 0) {
+    return (
+      <Container>
+        <p>등록된 할 일이 없습니다.</p>
+      </Container>
+    );
+  }
+
+  return (
+    <Container>
+      <ul>
+        {store.todoList.map((todoItem) => (
+          <TodoItem
+            key={todoItem.id}
+            todoItem={todoItem}
+          />
+        ))}
+      </ul>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  ul {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+  }
+
+  > p {
+    padding-block: 3rem;
+    text-align: center;
+  }
+`;

--- a/src/constants/testId.ts
+++ b/src/constants/testId.ts
@@ -16,6 +16,13 @@ const TEST_ID = {
   },
   TODO: {
     TITLE: 'todo-page',
+    ADD_INPUT: 'new-todo-input',
+    ADD_BUTTON: 'new-todo-add-button',
+    MODIFY_INPUT: 'modify-input',
+    MODIFY_BUTTON: 'modify-button',
+    DELETE_BUTTON: 'delete-button',
+    SUBMIT_BUTTON: 'submit-button',
+    CANCEL_BUTTON: 'cancel-button',
   },
 };
 

--- a/src/hooks/useTodoStore.ts
+++ b/src/hooks/useTodoStore.ts
@@ -1,0 +1,7 @@
+import useStore from './useStore';
+
+import { todoStore } from '../stores/TodoStore';
+
+const useTodoStore = () => useStore(todoStore);
+
+export default useTodoStore;

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -1,7 +1,28 @@
+import useTodoStore from '../hooks/useTodoStore';
+
+import TEST_ID from '../constants/testId';
+
+import TodoAddField from '../components/TodoAddField';
+import TodoList from '../components/TodoList';
+
+import PageTitle from '../components/ui/PageTitle';
+import ErrorMessage from '../components/ui/ErrorMessage';
+
 export default function TodoPage() {
+  const store = useTodoStore();
+
   return (
     <div>
-      Todo
+      <PageTitle data-testid={TEST_ID.TODO.TITLE}>
+        할 일 목록
+      </PageTitle>
+
+      <TodoAddField />
+      <TodoList />
+
+      {store.errorMessage && (
+        <ErrorMessage message={store.errorMessage} />
+      )}
     </div>
   );
 }

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import axios, { AxiosInstance } from 'axios';
 
 import { DYNAMIC_API_PATHS, STATIC_API_PATHS } from '../constants/api';
@@ -10,6 +11,16 @@ export default class ApiService {
   constructor() {
     this.instance = axios.create({
       baseURL: API_BASE_URL,
+    });
+
+    this.instance.interceptors.request.use((config) => {
+      const accessToken = localStorage.getItem('accessToken');
+
+      if (accessToken) {
+        config.headers.Authorization = `Bearer ${accessToken}`;
+      }
+
+      return config;
     });
   }
 
@@ -45,18 +56,18 @@ export default class ApiService {
     return data;
   }
 
-  async createTodos({ todo } : {
+  async createTodo({ todo } : {
     todo: string
   }) {
     const { data } = await this.instance.post(
-      STATIC_API_PATHS.SIGNIN,
+      STATIC_API_PATHS.TODO,
       { todo },
     );
 
     return data;
   }
 
-  async updateTodos({ id, todo, isCompleted } : {
+  async updateTodo({ id, todo, isCompleted } : {
     id: number,
     todo: string,
     isCompleted: boolean,
@@ -69,7 +80,7 @@ export default class ApiService {
     return data;
   }
 
-  async deleteTodos({ id } : {
+  async deleteTodo({ id } : {
     id: number
   }) {
     await this.instance.delete(

--- a/src/stores/TodoStore.ts
+++ b/src/stores/TodoStore.ts
@@ -1,0 +1,106 @@
+import { apiService } from '../services/apiService';
+
+import { TodoItem } from '../types';
+
+import Store from './Store';
+
+export default class TodoStore extends Store {
+  todo = '';
+
+  todoList: TodoItem[] = [];
+
+  errorMessage = '';
+
+  changeTodo(todo: string) {
+    this.todo = todo;
+
+    this.publish();
+  }
+
+  resetTodo() {
+    this.todo = '';
+
+    this.publish();
+  }
+
+  setTodoList(todoList: TodoItem[]) {
+    this.todoList = todoList;
+
+    this.errorMessage = '';
+
+    this.publish();
+  }
+
+  addTodoItem(todoItem: TodoItem) {
+    this.todoList.push(todoItem);
+
+    this.publish();
+  }
+
+  updateTodoItem(todoItem: TodoItem) {
+    const index = this.todoList.findIndex((item) => item.id === todoItem.id);
+
+    this.todoList[index] = todoItem;
+
+    this.publish();
+  }
+
+  deleteTodoItem(id: number) {
+    this.todoList = this.todoList.filter((item) => item.id !== id);
+
+    this.publish();
+  }
+
+  setErrorMessage(message: string) {
+    this.errorMessage = message;
+
+    this.publish();
+  }
+
+  async fetchTodoList() {
+    try {
+      const todoList = await apiService.getTodos();
+
+      this.setTodoList(todoList);
+    } catch (e) {
+      this.setErrorMessage('데이터 요청 실패');
+    }
+  }
+
+  async createTodo(todo : string) {
+    try {
+      const todoItem = await apiService.createTodo({ todo });
+
+      this.addTodoItem(todoItem);
+      this.resetTodo();
+    } catch (e) {
+      this.setErrorMessage('추가 실패');
+    }
+  }
+
+  async updateTodo(
+    id: number,
+    todo: string,
+    isCompleted: boolean,
+  ) {
+    try {
+      const todoItem = await apiService.updateTodo({ id, todo, isCompleted });
+
+      this.updateTodoItem(todoItem);
+    } catch (e) {
+      this.setErrorMessage('수정 실패');
+    }
+  }
+
+  async deleteTodo(id : number) {
+    try {
+      await apiService.deleteTodo({ id });
+
+      this.deleteTodoItem(id);
+    } catch (e) {
+      this.setErrorMessage('추가 실패');
+    }
+  }
+}
+
+export const todoStore = new TodoStore();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export interface Todo {
+export interface TodoItem {
   id: number;
   todo: string;
   isCompleted: boolean;


### PR DESCRIPTION
[기능 구현 외]
- types import 시 폴더 이름과 파일 이름이 같아 불필요하게 Path가 길어지는 것 같아 파일 이름 index.ts로 변경
- 타입 파일에 정의한 `Todo`는 Todo 데이터 중 컨텐츠를 가지고 있는 속성이 `todo`와 이름이 겹쳐서 해당 Todo 컨텐츠 타입으로 오인할 가능성이 있어 `TodoItem` 으로 변경
- Todo 관련 네트워크 요청에서 사용자 인증을 위한 액세스 토큰을 `header`에 담도록 `axios Interceptors` 추가