### PR TITLE
[feat] Todo 페이지 접근 시 추가 input에 focus 하도록 설정

### DIFF
--- a/src/components/TodoAddField.tsx
+++ b/src/components/TodoAddField.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react';
+
 import styled from 'styled-components';
 
 import useTodoStore from '../hooks/useTodoStore';
@@ -9,6 +11,12 @@ import Button from './ui/Button';
 
 export default function TodoAddField() {
   const store = useTodoStore();
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
 
   const handleChangeInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     store.changeTodo(event.target.value);
@@ -30,6 +38,7 @@ export default function TodoAddField() {
         value={store.newTodo}
         testId={TEST_ID.TODO.ADD_INPUT}
         onChange={handleChangeInput}
+        ref={inputRef}
       />
       <Button
         type="submit"

--- a/src/components/TodoAddField.tsx
+++ b/src/components/TodoAddField.tsx
@@ -33,7 +33,6 @@ export default function TodoAddField() {
   return (
     <Container onSubmit={handleSubmit}>
       <InputBox
-        label="할 일 추가"
         type="text"
         value={store.newTodo}
         testId={TEST_ID.TODO.ADD_INPUT}

--- a/src/components/ui/InputBox.tsx
+++ b/src/components/ui/InputBox.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from 'react';
+
 import styled from 'styled-components';
 
 interface InputBoxProps {
@@ -9,22 +11,30 @@ interface InputBoxProps {
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
 }
 
-export default function InputBox({
-  type, label = '', value, testId, onChange, onBlur = undefined,
-}: InputBoxProps) {
-  return (
-    <Container>
-      {label && <span>{label}</span>}
-      <input
-        type={type}
-        value={value}
-        data-testid={testId}
-        onChange={onChange}
-        onBlur={onBlur}
-      />
-    </Container>
-  );
-}
+const InputBox = forwardRef<HTMLInputElement, InputBoxProps>(({
+  type, label, value, testId, onChange, onBlur,
+}, ref) => (
+  <Container>
+    {label && <span>{label}</span>}
+    <input
+      type={type}
+      value={value}
+      data-testid={testId}
+      onChange={onChange}
+      onBlur={onBlur}
+      ref={ref}
+    />
+  </Container>
+));
+
+InputBox.displayName = 'InputBox';
+
+InputBox.defaultProps = {
+  label: '',
+  onBlur: undefined,
+};
+
+export default InputBox;
 
 const Container = styled.label`
   display: flex;


### PR DESCRIPTION
- 해당 과정에서 `InputBox`가 `ref`를 props로 받을 수 있도록 `forwardRef` 사용
- Todo 추가 input의 불필요한 label 제거